### PR TITLE
Archive with debug flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,12 @@ PROJECT_NAME = $(EXTENSION_NAME)
 TARGET_NAME_XCFRAMEWORK = $(EXTENSION_NAME).xcframework
 SCHEME_NAME_XCFRAMEWORK = AEPUserProfileXCFramework
 
+CURR_DIR := ${CURDIR}
+
 SIMULATOR_ARCHIVE_PATH = ./build/ios_simulator.xcarchive/Products/Library/Frameworks/
+SIMULATOR_ARCHIVE_DSYM_PATH = $(CURR_DIR)/build/ios_simulator.xcarchive/dSYMs/
 IOS_ARCHIVE_PATH = ./build/ios.xcarchive/Products/Library/Frameworks/
+IOS_ARCHIVE_DSYM_PATH = $(CURR_DIR)/build/ios.xcarchive/dSYMs/
 
 lint-autocorrect:
 	swiftlint autocorrect
@@ -42,11 +46,10 @@ test: clean
 	@echo "######################################################################"
 	xcodebuild test -workspace $(PROJECT_NAME).xcworkspace -scheme $(PROJECT_NAME)Tests -destination 'platform=iOS Simulator,name=iPhone 11 Pro' -derivedDataPath build/out -enableCodeCoverage YES
 
-archive:
+archive: pod-update
 	xcodebuild archive -workspace $(PROJECT_NAME).xcworkspace -scheme $(SCHEME_NAME_XCFRAMEWORK) -archivePath "./build/ios.xcarchive" -sdk iphoneos -destination="iOS" SKIP_INSTALL=NO BUILD_LIBRARIES_FOR_DISTRIBUTION=YES
 	xcodebuild archive -workspace $(PROJECT_NAME).xcworkspace -scheme $(SCHEME_NAME_XCFRAMEWORK) -archivePath "./build/ios_simulator.xcarchive" -sdk iphonesimulator -destination="iOS Simulator" SKIP_INSTALL=NO BUILD_LIBRARIES_FOR_DISTRIBUTION=YES
-	xcodebuild -create-xcframework -framework $(SIMULATOR_ARCHIVE_PATH)$(EXTENSION_NAME).framework -framework $(IOS_ARCHIVE_PATH)$(EXTENSION_NAME).framework -output ./build/$(TARGET_NAME_XCFRAMEWORK)
-
+	xcodebuild -create-xcframework -framework $(SIMULATOR_ARCHIVE_PATH)$(EXTENSION_NAME).framework -debug-symbols $(SIMULATOR_ARCHIVE_DSYM_PATH)$(EXTENSION_NAME).framework.dSYM -framework $(IOS_ARCHIVE_PATH)$(EXTENSION_NAME).framework -debug-symbols $(IOS_ARCHIVE_DSYM_PATH)$(EXTENSION_NAME).framework.dSYM -output ./build/$(TARGET_NAME_XCFRAMEWORK)
 latest-version:
 	(which jq)
 	(pod spec cat AEPUserProfile | jq '.version' | tr -d '"')

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,25 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "AEPCore",
+        "repositoryURL": "https://github.com/adobe/aepsdk-core-ios.git",
+        "state": {
+          "branch": "main",
+          "revision": "51a6bd926c8c0beb526604ac0c2bc01b86158cc8",
+          "version": null
+        }
+      },
+      {
+        "package": "AEPRulesEngine",
+        "repositoryURL": "https://github.com/adobe/aepsdk-rulesengine-ios.git",
+        "state": {
+          "branch": "main",
+          "revision": "b2e0247bf57975209997dd9a26fd576b7c420394",
+          "version": null
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,9 +1,9 @@
 PODS:
-  - AEPCore (3.0.0):
-    - AEPRulesEngine (= 1.0.0)
-    - AEPServices (= 3.0.0)
-  - AEPRulesEngine (1.0.0)
-  - AEPServices (3.0.0)
+  - AEPCore (3.3.1):
+    - AEPRulesEngine (= 1.0.1)
+    - AEPServices (= 3.3.1)
+  - AEPRulesEngine (1.0.1)
+  - AEPServices (3.3.1)
 
 DEPENDENCIES:
   - AEPCore
@@ -17,9 +17,9 @@ SPEC REPOS:
     - AEPServices
 
 SPEC CHECKSUMS:
-  AEPCore: 9ced1f1fddcbfd61517461e548e36aee740bf7c8
-  AEPRulesEngine: 8bbc694fce6900cd33b2496c7d4b33ee2eeffc46
-  AEPServices: 21ea64149483fdfbd5f88f546b9f5ad7d4987400
+  AEPCore: fc1398728b6b2a4dcc8dc96455f69ec144e087c0
+  AEPRulesEngine: 5075ed294026a12e37bd26fe260f74604d205354
+  AEPServices: c49e7b6ef17ec9f874b015f68ac7d2436235282f
 
 PODFILE CHECKSUM: cb4291c6eb5d180aa3ea5f46a4c2a7e0191bc077
 


### PR DESCRIPTION
Add debug flag to archive command in order to include debug symbols in xcframeworks when archiving. Also runs pod update first in order to make sure dependencies are up to date to avoid abi stability issues.