### PR TITLE
Make log tag internal access again

### DIFF
--- a/AEPUserProfile/Sources/UserProfile.swift
+++ b/AEPUserProfile/Sources/UserProfile.swift
@@ -16,7 +16,7 @@ import Foundation
 
 @objc(AEPMobileUserProfile)
 public class UserProfile: NSObject, Extension {
-    private static let LOG_TAG = "UserProfile"
+    static let LOG_TAG = "UserProfile"
 
     private let dataStore: NamedCollectionDataStore
     private var attributes: [String: Any]


### PR DESCRIPTION
Log tag is used by other extensions for migration logic logging.

